### PR TITLE
dev-util/ruyi: fix build error for 0.23.0

### DIFF
--- a/dev-util/ruyi/ruyi-0.23.0.ebuild
+++ b/dev-util/ruyi/ruyi-0.23.0.ebuild
@@ -15,7 +15,7 @@ MY_P="${PN}-${MY_PV}"
 DESCRIPTION="RuyiSDK Package Manager"
 HOMEPAGE="https://github.com/ruyisdk/ruyi"
 SRC_URI="https://github.com/ruyisdk/ruyi/releases/download/${MY_PV}/${MY_P}.tar.gz"
-S="${WORKDIR}/${MY_P}"
+S="${WORKDIR}"
 
 LICENSE="Apache-2.0"
 SLOT="0"


### PR DESCRIPTION
Build error log:
```log
>>> Emerging (1 of 1) dev-util/ruyi-0.23.0::ruyisdk
 * ruyi-0.23.0.tar.gz BLAKE2B SHA512 size ;-) ... [ ok ]
>>> Unpacking source...
>>> Unpacking ruyi-0.23.0.tar.gz to /var/tmp/portage/dev-util/ruyi-0.23.0/work
>>> Source unpacked in /var/tmp/portage/dev-util/ruyi-0.23.0/work
 * ERROR: dev-util/ruyi-0.23.0::ruyisdk failed (prepare phase):
 *   The source directory '/var/tmp/portage/dev-util/ruyi-0.23.0/work/ruyi-0.23.0' doesn't exist
 *
 * Call stack:
 *            ebuild.sh, line  784:  Called __ebuild_main 'prepare'
 *   phase-functions.sh, line 1074:  Called __dyn_prepare
 *   phase-functions.sh, line  400:  Called die
 * The specific snippet of code:
 *   		die "The source directory '${S}' doesn't exist"
 *
 * If you need support, post the output of `emerge --info '=dev-util/ruyi-0.23.0::ruyisdk'`,
 * the complete build log and the output of `emerge -pqv '=dev-util/ruyi-0.23.0::ruyisdk'`.
 * The complete build log is located at '/var/tmp/portage/dev-util/ruyi-0.23.0/temp/build.log'.
 * The ebuild environment file is located at '/var/tmp/portage/dev-util/ruyi-0.23.0/temp/environment'.
 * Working directory: '/var/tmp/portage/dev-util/ruyi-0.23.0/empty'
 * S: '/var/tmp/portage/dev-util/ruyi-0.23.0/work/ruyi-0.23.0'
```